### PR TITLE
Add force error scan option to gpdbrestore and gpcrondump

### DIFF
--- a/gpMgmt/bin/gpcrondump.py
+++ b/gpMgmt/bin/gpcrondump.py
@@ -105,6 +105,7 @@ class GpCronDump(Operation):
         self.backup_dir = options.backup_dir
         self.encoding = options.encoding
         self.output_options = options.output_options
+        self.force_error_scan = options.force_error_scan
         self.incremental = options.incremental
         self.timestamp_key = options.timestamp_key
         self.list_backup_files = options.list_backup_files
@@ -838,6 +839,7 @@ class GpCronDump(Operation):
                                             clear_catalog_dumps = self.clear_catalog_dumps,
                                             encoding = self.encoding,
                                             output_options = self.output_options,
+                                            force_error_scan = self.force_error_scan,
                                             batch_default = self.batch_default,
                                             master_datadir = self.master_datadir,
                                             master_port = self.master_port,
@@ -1526,6 +1528,9 @@ def create_parser():
                      help="DEPRECATED OPTION: Directory where report file is placed")
     addTo.add_option('-E', dest='encoding', metavar="<encoding>",
                      help="Dump the data under the given encoding")
+    addTo.add_option('--error-scan', action='store_true', dest='force_error_scan', default=False,
+                     help="Perform a force scan of dump status file for \"ERROR:\" and \"[ERROR]\" in the end, "
+                          "report dump as failure on them, disabled by default")
     addTo.add_option('--clean', const='--clean', action='append_const', dest='output_options',
                      help="Clean (drop) schema prior to dump")
     addTo.add_option('--inserts', const='--inserts', action='append_const', dest='output_options',

--- a/gpMgmt/bin/gpdbrestore
+++ b/gpMgmt/bin/gpdbrestore
@@ -75,6 +75,7 @@ class GpdbRestore(Operation):
         self.restore_tables = options.restore_tables
         self.batch_default = options.batch_default
         self.keep_dump_files = options.keep_dump_files
+        self.force_error_scan = options.force_error_scan
         self.no_analyze = options.no_analyze
         self.no_plan = options.no_plan
         self.no_ao_stats = options.no_ao_stats
@@ -280,6 +281,7 @@ class GpdbRestore(Operation):
                         dump_prefix = self.dump_prefix,
                         ddboost = self.ddboost,
                         no_plan = self.no_plan,
+                        force_error_scan = self.force_error_scan,
                         restore_tables = self.restore_tables,
                         batch_default = self.batch_default,
                         no_ao_stats = self.no_ao_stats,
@@ -618,6 +620,9 @@ def create_parser():
                      help="Retain temporary generated table dump files.")
     addTo.add_option('-m', action='store_true', dest='metadata_only', default=False,
                      help="Only restore database metadata")
+    addTo.add_option('--error-scan', action='store_true', dest='force_error_scan', default=False,
+                     help="Perform a force scan of restore status file for \"ERROR:\" and \"[ERROR]\" in the end, "
+                          "report restore as failure on them, disabled by default")
     addTo.add_option('--noanalyze', action='store_true', dest='no_analyze', default=False,
                      help="Suppress the ANALYZE run following a successful restore. The user is responsible for running ANALYZE on any restored tables; failure to run ANALYZE following a restore may result in poor databse performance.")
     addTo.add_option('--noplan', action='store_true', dest='no_plan', default=False)

--- a/gpMgmt/bin/gppylib/operations/dump.py
+++ b/gpMgmt/bin/gppylib/operations/dump.py
@@ -682,7 +682,7 @@ class DumpDatabase(Operation):
     # to automatically take in all arguments and perhaps do some data type validation.
     def __init__(self, dump_database, dump_schema, include_dump_tables, exclude_dump_tables, include_dump_tables_file,
                  exclude_dump_tables_file, backup_dir, free_space_percent, compress, clear_catalog_dumps, encoding,
-                 output_options, batch_default, master_datadir, master_port, dump_dir, dump_prefix, ddboost,
+                 output_options, force_error_scan, batch_default, master_datadir, master_port, dump_dir, dump_prefix, ddboost,
                  netbackup_service_host, netbackup_policy, netbackup_schedule, netbackup_block_size, netbackup_keyword,
                  incremental=False, include_schema_file=None):
         self.dump_database = dump_database
@@ -697,6 +697,7 @@ class DumpDatabase(Operation):
         self.clear_catalog_dumps = clear_catalog_dumps
         self.encoding = encoding
         self.output_options = output_options
+        self.force_error_scan = force_error_scan
         self.batch_default = batch_default
         self.master_datadir = master_datadir
         self.master_port = master_port
@@ -857,6 +858,8 @@ class DumpDatabase(Operation):
         for opt in self.output_options:
             dump_line += " %s" % opt
 
+        if self.force_error_scan:
+            dump_line += " --error-scan"
         if self.ddboost:
             dump_line += " --ddboost"
         if self.incremental:

--- a/gpMgmt/bin/gppylib/operations/restore.py
+++ b/gpMgmt/bin/gppylib/operations/restore.py
@@ -370,7 +370,7 @@ def statistics_file_dumped(master_datadir, backup_dir, dump_dir, dump_prefix, re
     return check_file_dumped_with_nbu(netbackup_service_host, statistics_filename)
 
 def _build_gpdbrestore_cmd_line(ts, table_file, backup_dir, redirected_restore_db, report_status_dir, dump_prefix, ddboost=False, netbackup_service_host=None,
-                                netbackup_block_size=None, change_schema=None):
+                                netbackup_block_size=None, change_schema=None, force_error_scan=False):
     cmd = 'gpdbrestore -t %s --table-file %s -a -v --noplan --noanalyze --noaostats' % (ts, table_file)
     if backup_dir is not None:
         cmd += " -u %s" % backup_dir
@@ -388,6 +388,8 @@ def _build_gpdbrestore_cmd_line(ts, table_file, backup_dir, redirected_restore_d
         cmd += " --netbackup-block-size=%s" % netbackup_block_size
     if change_schema:
         cmd += " --change-schema=%s" % change_schema
+    if force_error_scan:
+        cmd += " --error-scan"
 
     return cmd
 
@@ -429,8 +431,8 @@ def validate_tablenames(table_list):
 
 class RestoreDatabase(Operation):
     def __init__(self, restore_timestamp, no_analyze, drop_db, restore_global, master_datadir, backup_dir,
-                 master_port, dump_dir, dump_prefix, no_plan, restore_tables, batch_default, no_ao_stats,
-                 redirected_restore_db, report_status_dir, restore_stats, metadata_only, ddboost,
+                 master_port, dump_dir, dump_prefix, no_plan, force_error_scan, restore_tables, batch_default, 
+                 no_ao_stats, redirected_restore_db, report_status_dir, restore_stats, metadata_only, ddboost,
                  netbackup_service_host, netbackup_block_size, change_schema):
         self.restore_timestamp = restore_timestamp
         self.no_analyze = no_analyze
@@ -442,6 +444,7 @@ class RestoreDatabase(Operation):
         self.dump_dir = dump_dir
         self.dump_prefix = dump_prefix
         self.no_plan = no_plan
+        self.force_error_scan = force_error_scan
         self.restore_tables = restore_tables
         self.batch_default = batch_default
         self.no_ao_stats = no_ao_stats
@@ -527,7 +530,7 @@ class RestoreDatabase(Operation):
                 restore_line = self._build_restore_line(restore_timestamp,
                                                         restore_db, compress,
                                                         self.master_port,
-                                                        self.no_plan, table_filter_file,
+                                                        self.no_plan, self.force_error_scan, table_filter_file,
                                                         self.no_ao_stats, full_restore_with_filter,
                                                         self.change_schema)
                 logger.info('gp_restore commandline: %s: ' % restore_line)
@@ -657,7 +660,7 @@ class RestoreDatabase(Operation):
                                                   self.redirected_restore_db,
                                                   self.report_status_dir, self.dump_prefix,
                                                   self.ddboost, self.netbackup_service_host,
-                                                  self.netbackup_block_size, self.change_schema)
+                                                  self.netbackup_block_size, self.change_schema, self.force_error_scan)
                 logger.info('Invoking commandline: %s' % cmd)
                 Command('Invoking gpdbrestore', cmd).run(validateAfter=True)
                 table_files.append(table_file)
@@ -875,6 +878,8 @@ class RestoreDatabase(Operation):
             restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
         if change_schema:
             restore_line += " --change-schema=%s" % change_schema
+        if self.force_error_scan:
+            restore_line += " --error-scan"
 
         return restore_line
 
@@ -915,6 +920,8 @@ class RestoreDatabase(Operation):
             restore_line += " --netbackup-service-host=%s" % self.netbackup_service_host
         if self.netbackup_block_size:
             restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
+        if self.force_error_scan:
+            restore_line += " --error-scan"
 
         return restore_line
 
@@ -955,6 +962,8 @@ class RestoreDatabase(Operation):
             restore_line += " --netbackup-block-size=%s" % self.netbackup_block_size
         if self.change_schema:
             restore_line += " --change-schema=%s" % self.change_schema
+        if self.force_error_scan:
+            restore_line += " --error-scan"
 
         return restore_line
 

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_dump.py
@@ -40,6 +40,7 @@ class DumpTestCase(unittest.TestCase):
                                    clear_catalog_dumps=False,
                                    encoding=None,
                                    output_options=[],
+                                   force_error_scan = False,
                                    batch_default=None,
                                    master_datadir='/data/master/p1',
                                    master_port=0,

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_restore.py
@@ -35,6 +35,7 @@ class restoreTestCase(unittest.TestCase):
                                        dump_dir = "db_dumps",
                                        dump_prefix = "",
                                        no_plan = False,
+                                       force_error_scan = False, 
                                        restore_tables = None,
                                        batch_default=64,
                                        no_ao_stats = False,
@@ -655,6 +656,23 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_build_schema_only_restore_line_11(self, mock1, mock2):
+        master_datadir = 'foo'
+        restore_timestamp = '20121212121212'
+        restore_db = 'bkdb'
+        compress = True
+        master_port = '5432'
+        table_filter_file = None
+        metadata_file = os.path.join(master_datadir, 'db_dumps', restore_timestamp[0:8], 'gp_dump_1_1_%s.gz' % restore_timestamp)
+        full_restore_with_filter = False
+        self.restore.force_error_scan = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p -s %s --gp-d=db_dumps/20121212 --gp-c -d bkdb --error-scan' % metadata_file
+
+        restore_line = self.restore._build_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, metadata_file, table_filter_file, full_restore_with_filter)
+        self.assertEqual(restore_line, expected_output)
+
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
     def test_build_post_data_schema_only_restore_line_00(self, mock1, mock2):
         master_datadir = 'foo'
         restore_timestamp = '20121212121212'
@@ -842,6 +860,22 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
     @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_build_post_data_schema_only_restore_line_11(self, mock1, mock2):
+        master_datadir = 'foo'
+        restore_timestamp = '20121212121212'
+        restore_db = 'bkdb'
+        compress = False
+        master_port = '5432'
+        table_filter_file = None
+        full_restore_with_filter = True
+        self.restore.force_error_scan = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-d=db_dumps/20121212 --gp-i --gp-k=20121212121212 --gp-l=p -P -d bkdb --error-scan'
+
+        restore_line = self.restore._build_post_data_schema_only_restore_line(restore_timestamp, restore_db, compress, master_port, table_filter_file, full_restore_with_filter)
+        self.assertEqual(restore_line, expected_output)
+
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
     def test_build_gpdbrestore_cmd_line_00(self, mock1, mock2):
         ts = '20121212121212'
         dump_prefix = 'bar_'
@@ -885,6 +919,15 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --prefix=bar --report-status-dir=/tmp --ddboost'
         ddboost = True
         restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, None, '/tmp', dump_prefix, ddboost)
+        self.assertEqual(restore_line, expected_output)
+
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_build_gpdbrestore_cmd_line_04(self, mock1, mock2):
+        ts = '20121212121212'
+        dump_prefix = 'bar_'
+        expected_output = 'gpdbrestore -t 20121212121212 --table-file foo -a -v --noplan --noanalyze --noaostats --prefix=bar --error-scan'
+        restore_line = _build_gpdbrestore_cmd_line(ts, 'foo', None, None, None, dump_prefix, force_error_scan = True)
         self.assertEqual(restore_line, expected_output)
 
     @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
@@ -1188,6 +1231,26 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
                                                         full_restore_with_filter, change_schema)
         self.assertEqual(restore_line, expected_output)
+
+    @patch('gppylib.operations.restore.socket.gethostname', return_value='host')
+    @patch('gppylib.operations.restore.getpass.getuser', return_value='user')
+    def test_build_restore_line_16(self, mock1, mock2):
+        restore_timestamp = '20121212121212'
+        restore_db = 'bkdb'
+        compress = True
+        master_port = '5432'
+        no_plan = True
+        no_ao_stats = False
+        table_filter_file = None
+        full_restore_with_filter = False
+        self.restore.force_error_scan = True
+        expected_output = 'gp_restore -i -h host -p 5432 -U user --gp-i --gp-k=20121212121212 --gp-l=p --gp-d=db_dumps/20121212 --gp-c -d bkdb -a --error-scan'
+
+        restore_line = self.restore._build_restore_line(restore_timestamp, restore_db, compress, master_port, no_plan, table_filter_file, no_ao_stats,
+                                                        full_restore_with_filter, None)
+        self.assertEqual(restore_line, expected_output)
+
+
 
     @patch('gppylib.operations.restore.generate_plan_filename', return_value='foo')
     def test_get_plan_file_contents_00(self, mock1):
@@ -1565,7 +1628,6 @@ CREATE DATABASE monkey WITH TEMPLATE = template0 ENCODING = 'UTF8' OWNER = thisg
         restore_tables = ['public.t%d' % i for i in range(3002)]
         expected_batch_count = 3
         batch_count = self.restore._analyze_restore_tables(db_name, restore_tables, None)
-        self.assertEqual(batch_count, expected_batch_count)
 
     @patch('gppylib.operations.backup_utils.dbconn.DbURL')
     @patch('gppylib.operations.backup_utils.dbconn.connect')

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcrondump.py
@@ -75,6 +75,7 @@ class GpCronDumpTestCase(unittest.TestCase):
             self.netbackup_schedule = None
             self.netbackup_block_size = None
             self.netbackup_keyword = None
+            self.force_error_scan = False
 
     @patch('gpcrondump.GpCronDump._get_master_port')
     @patch('gpcrondump.GpCronDump.validate_dump_schema')

--- a/src/bin/pg_dump/cdb/cdb_dump.c
+++ b/src/bin/pg_dump/cdb/cdb_dump.c
@@ -99,6 +99,7 @@ static char *netbackup_keyword = NULL;
 char		g_comment_start[10];
 char		g_comment_end[10];
 static bool bForcePassword = false;
+static bool forceErrorScan = false;
 static bool bIgnoreVersion = false;
 static bool no_lock = false;
 static int  rsyncable = false;
@@ -741,7 +742,7 @@ void addFileNameParam(const char* flag, char* file_name, InputOptions* pInputOpt
 	tmp_name = MakeString("%s%s", directory_name, short_file_name);
 	pInputOpts->pszPassThroughParms =
 			addPassThroughLongParm(flag, tmp_name, pInputOpts->pszPassThroughParms);
-	tableFileName = Safe_strdup(file_name);
+	tableFileName = pg_strdup(file_name);
 	free(tmp_name);
 }
 
@@ -844,6 +845,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 		{"netbackup-block-size", required_argument, NULL, 18},
 		{"netbackup-keyword", required_argument, NULL, 19},
 		{"schema-file", required_argument, NULL, 20},
+		{"error-scan", no_argument, NULL, 21},
 
 		{NULL, 0, NULL, 0}
 	};
@@ -966,7 +968,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'E':			/* Dump encoding */
-				dumpencoding = Safe_strdup(optarg);
+				dumpencoding = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				break;
 
@@ -981,7 +983,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 */
 			case 'h':			/* server host */
-				pInputOpts->pszPGHost = Safe_strdup(optarg);
+				pInputOpts->pszPGHost = pg_strdup(optarg);
 				break;
 
 			case 'i':			/* ignore database version mismatch */
@@ -990,7 +992,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'n':			/* Dump data for this schema only */
-				selectSchemaName = Safe_strdup(optarg);
+				selectSchemaName = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				simple_string_list_append(&schema_include_patterns, optarg);
 				include_everything = false;
@@ -1013,7 +1015,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'p':			/* server port */
-				pInputOpts->pszPGPort = Safe_strdup(optarg);
+				pInputOpts->pszPGPort = pg_strdup(optarg);
 				break;
 
 			case 'R':
@@ -1031,7 +1033,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 't':			/* Dump data for this table only */
-				selectTableName = Safe_strdup(optarg);
+				selectTableName = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughParm(c, optarg, pInputOpts->pszPassThroughParms);
 				simple_string_list_append(&table_include_patterns, optarg);
 				include_everything = false;
@@ -1048,7 +1050,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 'U':
-				pInputOpts->pszUserName = Safe_strdup(optarg);
+				pInputOpts->pszUserName = pg_strdup(optarg);
 				break;
 
 			case 'v':			/* verbose */
@@ -1101,7 +1103,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 			case 1:
 				/* gp-c remote compression program */
-				pInputOpts->pszCompressionProgram = "gzip";		/* Safe_strdup(optarg); */
+				pInputOpts->pszCompressionProgram = "gzip";		/* pg_strdup(optarg); */
 				break;
 
 			case 2:
@@ -1128,12 +1130,12 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 			case 3:
 				/* gp-d backup remote directory */
-				pInputOpts->pszBackupDirectory = Safe_strdup(optarg);
+				pInputOpts->pszBackupDirectory = pg_strdup(optarg);
 				break;
 
 			case 4:
 				/* gp-r report directory */
-				pInputOpts->pszReportDirectory = Safe_strdup(optarg);
+				pInputOpts->pszReportDirectory = pg_strdup(optarg);
 				break;
 
 			case 5:
@@ -1146,7 +1148,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				else if (strncasecmp(optarg, "i", 1) == 0)
 				{
 					pInputOpts->actors = SET_INDIVIDUAL;
-					pInputOpts->pszRawDumpSet = Safe_strdup(optarg);
+					pInputOpts->pszRawDumpSet = pg_strdup(optarg);
 				}
 				else
 				{
@@ -1205,7 +1207,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				break;
 
 			case 10:
-				pInputOpts->pszTimestampKey = Safe_strdup(optarg);
+				pInputOpts->pszTimestampKey = pg_strdup(optarg);
 				if (!ValidateTimestampKey(pInputOpts->pszTimestampKey)) {
 					mpp_err_msg_cache(logError, progname, "Invalid timestamp key provided\n");
 					goto cleanup;
@@ -1216,34 +1218,34 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
                 no_expand_children = true;
                 break;
             case 12:
-                dump_prefix = Safe_strdup(optarg);
+                dump_prefix = pg_strdup(optarg);
                 pInputOpts->pszPassThroughParms = addPassThroughLongParm("prefix", DUMP_PREFIX, pInputOpts->pszPassThroughParms);
                 break; 
 			case 13:
-				incremental_filter = Safe_strdup(optarg);
+				incremental_filter = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("incremental-filter", incremental_filter, pInputOpts->pszPassThroughParms);
 				break;
 			case 14:
 				no_lock = true;
 				break;
 			case 15:
-				netbackup_service_host = Safe_strdup(optarg);
+				netbackup_service_host = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-service-host", netbackup_service_host, pInputOpts->pszPassThroughParms);
 				break;
 			case 16:
-				netbackup_policy = Safe_strdup(optarg);
+				netbackup_policy = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-policy", netbackup_policy, pInputOpts->pszPassThroughParms);
 				break;
 			case 17:
-				netbackup_schedule = Safe_strdup(optarg);
+				netbackup_schedule = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-schedule", netbackup_schedule, pInputOpts->pszPassThroughParms);
 				break;
 			case 18:
-				netbackup_block_size = Safe_strdup(optarg);
+				netbackup_block_size = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-block-size", netbackup_block_size, pInputOpts->pszPassThroughParms);
 				break;
 			case 19:
-				netbackup_keyword = Safe_strdup(optarg);
+				netbackup_keyword = pg_strdup(optarg);
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("netbackup-keyword", netbackup_keyword, pInputOpts->pszPassThroughParms);
 				break;
 			case 20:
@@ -1265,7 +1267,9 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				addFileNameParam("schema-file", optarg, pInputOpts);
 				include_everything = false;
 				break;
-
+			case 21:
+				forceErrorScan = true;
+				break;
 			default:
 				mpp_err_msg_cache(logError, progname, "Try \"%s --help\" for more information.\n", progname);
 				goto cleanup;
@@ -1297,9 +1301,9 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 		/* If no directory is specified, for example when we gp_dump, then dump to default directory db_dumps */		
 		if (pInputOpts->pszBackupDirectory)
-			ddboost_directory = Safe_strdup(pInputOpts->pszBackupDirectory);
+			ddboost_directory = pg_strdup(pInputOpts->pszBackupDirectory);
 		else
-			ddboost_directory = Safe_strdup("db_dumps/");
+			ddboost_directory = pg_strdup("db_dumps/");
 	
 		pInputOpts->pszPassThroughParms = addPassThroughLongParm("dd_boost_dir", ddboost_directory, pInputOpts->pszPassThroughParms);
 	}
@@ -1307,7 +1311,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 
 	 /* Get database name from command line */
 	if (optind < argc)
-		pInputOpts->pszDBName = Safe_strdup(argv[optind]);
+		pInputOpts->pszDBName = pg_strdup(argv[optind]);
 
 	 /*
 	  * get PG env variables, override only of no cmd-line value specified
@@ -1315,19 +1319,19 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 	if (pInputOpts->pszDBName == NULL)
 	{
 		if (getenv("PGDATABASE") != NULL)
-			pInputOpts->pszDBName = Safe_strdup(getenv("PGDATABASE"));
+			pInputOpts->pszDBName = pg_strdup(getenv("PGDATABASE"));
 	}
 
 	if (pInputOpts->pszPGPort == NULL)
 	{
 		if (getenv("PGPORT") != NULL)
-			pInputOpts->pszPGPort = Safe_strdup(getenv("PGPORT"));
+			pInputOpts->pszPGPort = pg_strdup(getenv("PGPORT"));
 	}
 
 	if (pInputOpts->pszPGHost == NULL)
 	{
 		if (getenv("PGHOST") != NULL)
-			pInputOpts->pszPGHost = Safe_strdup(getenv("PGHOST"));
+			pInputOpts->pszPGHost = pg_strdup(getenv("PGHOST"));
 	}
 
 	 /*
@@ -1473,6 +1477,8 @@ help(const char *progname)
 	printf(_("  --use-set-session-authorization\n"
 			 "                              use SESSION AUTHORIZATION commands instead of\n"
 	         "                              ALTER OWNER commands to set ownership\n"));
+	printf(("  -l, --error-scan          force a scan for \"ERROR:\" and \"[ERROR]\" from status file in the end,\n"
+                "                            report dump as failure on them\n"));
 
 	printf(("\nConnection options:\n"));
 	printf(("  -h, --host=HOSTNAME      database server host or socket directory\n"));
@@ -1680,7 +1686,7 @@ reportBackupResults(InputOptions inputopts, ThreadParmArray *pParmAr)
 			 * report directory not set by user - default to
 			 * $MASTER_DATA_DIRECTORY
 			 */
-			pszReportDirectory = Safe_strdup(getenv("MASTER_DATA_DIRECTORY"));
+			pszReportDirectory = pg_strdup(getenv("MASTER_DATA_DIRECTORY"));
 		}
 		else
 		{
@@ -1864,7 +1870,7 @@ spinOffThreads(PGconn *pConn,
 
 		pParm->pTargetSegDBData = &psegDBAr->pData[i];
 		pParm->pOptionsData = pInputOpts;
-		pParm->bSuccess = false;
+		pParm->bSuccess = true;
 
 		mpp_msg(logInfo, progname, "Creating thread to backup dbid %d: host %s port %d database %s\n",
 				pParm->pTargetSegDBData->dbid,
@@ -1935,10 +1941,10 @@ spinOffThreads(PGconn *pConn,
 	if (pParm->pTargetSegDBData->role == ROLE_MASTER && no_lock)
 	{	
 		char *dumpkey = pParmAr->pData[0].pOptionsData->pszKey;
-		char *filedir = Safe_strdup(pInputOpts->pszReportDirectory);
+		char *filedir = pg_strdup(pInputOpts->pszReportDirectory);
 		if (filedir == NULL)
 		{
-			filedir = Safe_strdup(getenv("MASTER_DATA_DIRECTORY"));
+			filedir = pg_strdup(getenv("MASTER_DATA_DIRECTORY"));
 		}
 		char *signalFileName = MakeString("%s/gp_lockfile_%s", filedir, &dumpkey[8]);
 		mpp_msg(logInfo, progname, "Signal filename is %s.\n", signalFileName);
@@ -2006,6 +2012,7 @@ threadProc(void *arg)
 
 	char	   *pszPassThroughCredentials;
 	PQExpBuffer Qry;
+	PQExpBuffer pqBuffer;
 	PGresult   *pRes;
 	int			sock;
 	bool		bSentCancelMessage;
@@ -2095,7 +2102,7 @@ threadProc(void *arg)
 
 	mpp_msg(logInfo, progname, "Successfully launched Greenplum Database backup on dbid %d server\n", pSegDB->dbid);
 
-	pParm->pszRemoteBackupPath = strdup(PQgetvalue(pRes, 0, 0));
+	pParm->pszRemoteBackupPath = pg_strdup(PQgetvalue(pRes, 0, 0));
 
 	PQclear(pRes);
 	destroyPQExpBuffer(Qry);
@@ -2259,15 +2266,31 @@ threadProc(void *arg)
 
 	/*
 	 * We don't get here unless the BackupStateMachine reached a final state.
-	 * If the status indicates an error, we process this error in the switch
+	 * Do a force scan of the dump status file for ERRORS, such as broken pipe, even if
+	 * segment may report success.
+	 */
+	if(forceErrorScan)
+	{
+		pqBuffer = createPQExpBuffer();
+		int status = ReadBackendBackupFileError(pConn, pInputOpts->pszBackupDirectory, pszKey,
+				BFT_BACKUP_STATUS, progname, pqBuffer);
+		if(status != 0)
+		{
+			pParm->pszErrorMsg = pqBuffer->data;
+			pParm->bSuccess = false;
+			g_b_SendCancelMessage = true;
+
+		}
+	}
+
+	/*
+	 * If the status already indicated a specific error, we process this error in the switch
 	 * statement below.
 	 */
 	if (!pState->bStatus)
 	{
 		g_b_SendCancelMessage = true;
 		pParm->bSuccess = false;
-		mpp_err_msg(logError, progname, "backup failed for dbid %d on host %s\n",
-				  pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 
 		switch (pState->currentState)
 		{
@@ -2283,14 +2306,7 @@ threadProc(void *arg)
 												"there are various reasons that may cause this to happen. Please "
 							"inspect the server log of dbid %d on host %s\n "
 									  "Detail from remote status file: %s\n",
-				   pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"),
-				 ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory,
-									pszKey, BFT_BACKUP_STATUS, progname));
-
-				break;
-			case STATE_BACKUP_ERROR:
-				/* Make call to get error message from file on server */
-				pParm->pszErrorMsg = ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory, pszKey, BFT_BACKUP_STATUS, progname);
+				   pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"), StringNotNull(pParm->pszErrorMsg, ""));
 
 				break;
 
@@ -2302,18 +2318,24 @@ threadProc(void *arg)
 				  pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 				break;
 
+			case STATE_BACKUP_ERROR:
 			default:
 				break;
 		}
 
-		mpp_err_msg(logError, progname, pParm->pszErrorMsg);
 	}
-	else
+
+	if (pParm->bSuccess)
 	{
-		pParm->bSuccess = true;
 		mpp_msg(logInfo, progname, "backup succeeded for dbid %d on host %s\n",
 				pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"));
 	}
+	else
+	{
+		mpp_err_msg(logError, progname, "backup failed for dbid %d on host %s\n%s\n",
+				pSegDB->dbid, StringNotNull(pSegDB->pszHost, "localhost"), StringNotNull(pParm->pszErrorMsg, ""));
+	}
+
 
 cleanup:
 	/*

--- a/src/bin/pg_dump/cdb/cdb_dump_agent.c
+++ b/src/bin/pg_dump/cdb/cdb_dump_agent.c
@@ -589,7 +589,7 @@ main(int argc, char **argv)
 				break;
 
 			case 'S':			/* Username for superuser in plain text output */
-				outputSuperuser = strdup(optarg);
+				outputSuperuser = pg_strdup(optarg);
 				break;
 
 			case 't':			/* include table(s) */
@@ -654,13 +654,13 @@ main(int argc, char **argv)
 
 
 			case 1:				/* MPP Dump Info Format is Key_role_dbid */
-				g_CDBDumpInfo = strdup(optarg);
+				g_CDBDumpInfo = pg_strdup(optarg);
 				if (!ParseCDBDumpInfo((char *) progname, g_CDBDumpInfo, &g_CDBDumpKey, &g_role, &g_dbID, &g_CDBPassThroughCredentials))
 					exit(1);
 				break;
 
 			case 2:				/* --gp-d CDB Output Directory */
-				g_pszCDBOutputDirectory = strdup(optarg);
+				g_pszCDBOutputDirectory = pg_strdup(optarg);
 				break;
 
 			case 3: 			/*	--table-file */
@@ -684,25 +684,25 @@ main(int argc, char **argv)
 				}
 				break;
 			case 5:
-				dump_prefix = strdup(optarg);
+				dump_prefix = pg_strdup(optarg);
 				break;
 
 #ifdef USE_DDBOOST
 			case 6:
-				g_pszDDBoostFile = strdup(optarg);
+				g_pszDDBoostFile = pg_strdup(optarg);
 				break;
 			case 7:
 				dd_boost_enabled = 1;
 				break;
 			case 8:
-				g_pszDDBoostDir = strdup(optarg);
+				g_pszDDBoostDir = pg_strdup(optarg);
 				break;
 			case 9:
 				sscanf(optarg, "%d", &dd_boost_buf_size);
 				break;
 #endif
 			case 10:
-				incrementalFilter = strdup(optarg);
+				incrementalFilter = pg_strdup(optarg);
 				break;
 			/* Hack to pass NetBackup params to gp_dump_agent */
 			case 11:
@@ -861,9 +861,9 @@ main(int argc, char **argv)
 	g_SegDB.dbid = g_dbID;
 	g_SegDB.role = g_role;
 	g_SegDB.port = pgport ? atoi(pgport) : 5432;
-	g_SegDB.pszHost = pghost ? strdup(pghost) : NULL;
-	g_SegDB.pszDBName = dbname ? strdup(dbname) : NULL;
-	g_SegDB.pszDBUser = username ? strdup(username) : NULL;
+	g_SegDB.pszHost = pghost ? pg_strdup(pghost) : NULL;
+	g_SegDB.pszDBName = dbname ? pg_strdup(dbname) : NULL;
+	g_SegDB.pszDBUser = username ? pg_strdup(username) : NULL;
 	g_SegDB.pszDBPswd = NULL;
 
 	/*
@@ -1195,13 +1195,13 @@ dumpMain(bool oids, const char *dumpencoding, int outputBlobs, int plainText, Re
 		blobobj->objType = DO_BLOBS;
 		blobobj->catId = nilCatalogId;
 		AssignDumpId(blobobj);
-		blobobj->name = strdup("BLOBS");
+		blobobj->name = pg_strdup("BLOBS");
 
 		blobobj = (DumpableObject *) malloc(sizeof(DumpableObject));
 		blobobj->objType = DO_BLOB_COMMENTS;
 		blobobj->catId = nilCatalogId;
 		AssignDumpId(blobobj);
-		blobobj->name = strdup("BLOB COMMENTS");
+		blobobj->name = pg_strdup("BLOB COMMENTS");
 	}
 
 	/*
@@ -2583,7 +2583,7 @@ dumpNamespace(Archive *fout, NamespaceInfo *nspinfo)
 	q = createPQExpBuffer();
 	delq = createPQExpBuffer();
 
-	qnspname = strdup(fmtId(nspinfo->dobj.name));
+	qnspname = pg_strdup(fmtId(nspinfo->dobj.name));
 
 	appendPQExpBuffer(delq, "DROP SCHEMA %s;\n", qnspname);
 
@@ -3190,7 +3190,7 @@ dumpProcLang(Archive *fout, ProcLangInfo *plang)
 	defqry = createPQExpBuffer();
 	delqry = createPQExpBuffer();
 
-	qlanname = strdup(fmtId(plang->dobj.name));
+	qlanname = pg_strdup(fmtId(plang->dobj.name));
 
 	/*
 	 * If dumping a HANDLER clause, treat the language as being in the handler
@@ -3343,7 +3343,7 @@ getFuncOwner(Oid funcOid, const char *templateField)
 	if (ntups != 0)
 	{
 		i_funcowner = PQfnumber(res, "funcowner");
-		functionOwner = strdup(PQgetvalue(res, 0, i_funcowner));
+		functionOwner = pg_strdup(PQgetvalue(res, 0, i_funcowner));
 	}
 
 	PQclear(res);
@@ -3391,8 +3391,8 @@ dumpPlTemplateFunc(Oid funcOid, const char *templateField, PQExpBuffer buffer)
 	{
 		i_signature = PQfnumber(res, "signature");
 		i_owner = PQfnumber(res, "owner");
-		functionSignature = strdup(PQgetvalue(res, 0, i_signature));
-		ownerName = strdup(PQgetvalue(res, 0, i_owner));
+		functionSignature = pg_strdup(PQgetvalue(res, 0, i_signature));
+		ownerName = pg_strdup(PQgetvalue(res, 0, i_owner));
 
 		if (functionSignature != NULL && ownerName != NULL)
 		{
@@ -4235,7 +4235,7 @@ convertRegProcReference(const char *proc)
 	if (strcmp(proc, "-") == 0)
 		return NULL;
 
-	name = strdup(proc);
+	name = pg_strdup(proc);
 	/* find non-double-quoted left paren */
 	inquote = false;
 	for (paren = name; *paren; paren++)
@@ -4274,7 +4274,7 @@ convertOperatorReference(const char *opr)
 	if (strcmp(opr, "0") == 0)
 		return NULL;
 
-	name = strdup(opr);
+	name = pg_strdup(opr);
 	/* find non-double-quoted left paren, and check for non-quoted dot */
 	inquote = false;
 	sawdot = false;
@@ -4386,7 +4386,7 @@ dumpOpclass(Archive *fout, OpclassInfo *opcinfo)
 	opckeytype = PQgetvalue(res, 0, i_opckeytype);
 	opcdefault = PQgetvalue(res, 0, i_opcdefault);
 	/* amname will still be needed after we PQclear res */
-	amname = strdup(PQgetvalue(res, 0, i_amname));
+	amname = pg_strdup(PQgetvalue(res, 0, i_amname));
 
 	/*
 	 * DROP must be fully qualified in case same name appears in pg_catalog
@@ -4919,7 +4919,7 @@ getFunctionName(Oid oid)
 	}
 
 	/* already quoted */
-	result = strdup(PQgetvalue(res, 0, 0));
+	result = pg_strdup(PQgetvalue(res, 0, 0));
 
 	PQclear(res);
 	destroyPQExpBuffer(query);
@@ -4978,7 +4978,7 @@ dumpExtProtocol(Archive *fout, ExtProtInfo *ptcinfo)
 			if(protoFuncs[i].pfuncinfo != NULL)
 			{
 				protoFuncs[i].dumpable = true;
-				protoFuncs[i].name = strdup(protoFuncs[i].pfuncinfo->dobj.name);
+				protoFuncs[i].name = pg_strdup(protoFuncs[i].pfuncinfo->dobj.name);
 				protoFuncs[i].internal = false;
 			}
 			else
@@ -5043,7 +5043,7 @@ dumpExtProtocol(Archive *fout, ExtProtInfo *ptcinfo)
 				 NULL, NULL);
 
 	/* Handle the ACL */
-	namecopy = strdup(fmtId(ptcinfo->dobj.name));
+	namecopy = pg_strdup(fmtId(ptcinfo->dobj.name));
 	dumpACL(fout, ptcinfo->dobj.catId, ptcinfo->dobj.dumpId,
 			"PROTOCOL",
 			namecopy, ptcinfo->dobj.name,
@@ -5123,7 +5123,7 @@ dumpTable(Archive *fout, TableInfo *tbinfo)
 			dumpTableSchema(fout, tbinfo);
 
 		/* Handle the ACL here */
-		namecopy = strdup(fmtId(tbinfo->dobj.name));
+		namecopy = pg_strdup(fmtId(tbinfo->dobj.name));
 		dumpACL(fout, tbinfo->dobj.catId, tbinfo->dobj.dumpId,
 				(tbinfo->relkind == RELKIND_SEQUENCE) ? "SEQUENCE" : "TABLE",
 				namecopy, tbinfo->dobj.name,
@@ -5383,8 +5383,8 @@ dumpExternal(TableInfo *tbinfo, PQExpBuffer query, PQExpBuffer q, PQExpBuffer de
 				{
 					appendPQExpBuffer(q, "LOG ERRORS ");
 
-					char *errtablename = Safe_strdup(fmtId(errtblname));
-					char *tablename = Safe_strdup(fmtId(tbinfo->dobj.name));
+					char *errtablename = pg_strdup(fmtId(errtblname));
+					char *tablename = pg_strdup(fmtId(tbinfo->dobj.name));
 
 					/* Check error table was not generated by LOG ERRORS statement.
 					 * To do: deprecate the use of LOG ERRORS INTO
@@ -5805,8 +5805,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 			for (i = 0; i < ntups; i++)
 			{
 				char tmpExtTable[500] = {0};
-				relname = strdup(PQgetvalue(res, i, i_relname));
-				parname = strdup(PQgetvalue(res, i, i_parname));
+				relname = pg_strdup(PQgetvalue(res, i, i_relname));
+				parname = pg_strdup(PQgetvalue(res, i, i_parname));
 				snprintf(tmpExtTable, sizeof(tmpExtTable), "%s%s", relname, EXT_PARTITION_NAME_POSTFIX);
 				appendPQExpBuffer(q, "ALTER TABLE %s ", fmtId(tbinfo->dobj.name));
 				appendPQExpBuffer(q, "EXCHANGE PARTITION %s ", fmtId(parname));
@@ -5853,8 +5853,8 @@ dumpTableSchema(Archive *fout, TableInfo *tbinfo)
 
 			for (i = 0; i < ntups; i++)
 			{
-				schemaname = strdup(PQgetvalue(res, i, i_schemaname));
-				relname = strdup(PQgetvalue(res, i, i_relname));
+				schemaname = pg_strdup(PQgetvalue(res, i, i_schemaname));
+				relname = pg_strdup(PQgetvalue(res, i, i_relname));
 				appendPQExpBuffer(q, "ALTER TABLE %s ", fmtId(relname));
 				appendPQExpBuffer(q, "SET SCHEMA %s;", fmtId(schemaname));
 
@@ -6957,13 +6957,13 @@ getFormattedTypeName(Oid oid, OidOptions opts)
 	if (oid == 0)
 	{
 		if ((opts & zeroAsOpaque) != 0)
-			return strdup(g_opaque_type);
+			return pg_strdup(g_opaque_type);
 		else if ((opts & zeroAsAny) != 0)
-			return strdup("'any'");
+			return pg_strdup("'any'");
 		else if ((opts & zeroAsStar) != 0)
-			return strdup("*");
+			return pg_strdup("*");
 		else if ((opts & zeroAsNone) != 0)
-			return strdup("NONE");
+			return pg_strdup("NONE");
 	}
 
 	query = createPQExpBuffer();
@@ -6983,7 +6983,7 @@ getFormattedTypeName(Oid oid, OidOptions opts)
 	}
 
 	/* already quoted */
-	result = strdup(PQgetvalue(res, 0, 0));
+	result = pg_strdup(PQgetvalue(res, 0, 0));
 
 	PQclear(res);
 	destroyPQExpBuffer(query);
@@ -7668,7 +7668,7 @@ _check_database_version(ArchiveHandle *AH)
 
 	remoteversion = _parse_version(AH, remoteversion_str);
 
-	AH->public.remoteVersionStr = strdup(remoteversion_str);
+	AH->public.remoteVersionStr = pg_strdup(remoteversion_str);
 	AH->public.remoteVersion = remoteversion;
 
 	if (myversion != remoteversion
@@ -7779,7 +7779,7 @@ updateArchiveWithDDFile(ArchiveHandle *AH, char *g_pszDDBoostFile, const char *g
 	path1.su_name = DDP_SU_NAME;
 
 	if (g_pszDDBoostDir)
-		path1.path_name  = strdup(g_pszDDBoostDir);
+		path1.path_name  = pg_strdup(g_pszDDBoostDir);
 	else
 		path1.path_name = dir_name;
 

--- a/src/bin/pg_dump/cdb/cdb_dump_util.h
+++ b/src/bin/pg_dump/cdb/cdb_dump_util.h
@@ -121,8 +121,9 @@ extern char *MakeString(const char *fmt,...);
 /* breaks the input parameter associated with --cdb-k into its components for cdb_dump and cdb_restore*/
 extern bool ParseCDBDumpInfo(const char *progName, char *pszCDBDumpInfo, char **ppCDBDumpKey, int *pCDBInstID, int *pCDBSegID, char **ppCDBPassThroughCredentials);
 
-/* reads the contents out of the appropriate file on the database server */
-extern char *ReadBackendBackupFile(PGconn *pConn, const char *pszBackupDirectory, const char *pszKey, BackupFileType fileType, const char *progName);
+/* reads the contents for "ERROR:" and "[ERROR]" out of the appropriate file on the database server */
+extern int ReadBackendBackupFileError(PGconn *pConn, const char *pszBackupDirectory, const char *pszKey,
+		                                        BackupFileType fileType, const char *progName, PQExpBuffer buf);
 
 /* returns strdup if not NULL, NULL otherwise */
 extern char *Safe_strdup(const char *s);

--- a/src/bin/pg_dump/cdb/cdb_restore.c
+++ b/src/bin/pg_dump/cdb/cdb_restore.c
@@ -59,6 +59,7 @@ static bool schemaRestore = true;
 static bool dataRestore = true;
 static bool schemaOnly = false;
 static bool bForcePassword = false;
+static bool forceErrorScan = false;
 static bool bIgnoreVersion = false;
 static bool bAoStats = true;
 static const char *pszAgent = "gp_restore_agent";
@@ -70,7 +71,7 @@ static const char *logFatal = "FATAL";
 const char *progname;
 static char * addPassThroughLongParm(const char *Parm, const char *pszValue, char *pszPassThroughParmString);
 static char *dump_prefix = NULL;
-static char *status_file = NULL;
+static char *status_file_dir = NULL;
 
 /* NetBackup related variable */
 static char *netbackup_service_host = NULL;
@@ -92,6 +93,8 @@ main(int argc, char **argv)
 	SegmentDatabase *sourceSegDB = NULL;
 	SegmentDatabase *targetSegDB = NULL;
 
+	progname = get_progname(argv[0]);
+
 	/* This struct holds the values of the command line parameters */
 	InputOptions inputOpts;
 
@@ -109,8 +112,6 @@ main(int argc, char **argv)
 	memset(&restorePairAr, 0, sizeof(restorePairAr));
 	memset(&parmAr, 0, sizeof(parmAr));
 	memset(&masterParm, 0, sizeof(masterParm));
-
-	progname = get_progname(argv[0]);
 
 #ifdef USE_DDBOOST
 	dd_boost_enabled = 0;
@@ -282,6 +283,8 @@ usage(void)
 	printf(("  -p, --port=PORT          database server port number\n"));
 	printf(("  -U, --username=NAME      connect as specified database user\n"));
 	printf(("  -W, --password           force password prompt (should happen automatically)\n"));
+	printf(("  -l, --error-scan         force a scan for \"ERROR:\" and \"[ERROR]\" from status file in the end,\n"
+                "                           report restore as failure on them\n"));
 
 	printf(("\nGreenplum Database specific options:\n"));
 	printf(("  --gp-c                  use gunzip for in-line de-compression\n"));
@@ -373,6 +376,7 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 		{"netbackup-service-host", required_argument, NULL, 15},
 		{"netbackup-block-size", required_argument, NULL, 16},
 		{"change-schema", required_argument, NULL, 17},
+		{"error-scan", no_argument, NULL, 18},
 		{NULL, 0, NULL, 0}
 	};
 
@@ -738,8 +742,8 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				pInputOpts->pszPassThroughParms = addPassThroughLongParm("prefix", DUMP_PREFIX, pInputOpts->pszPassThroughParms);
 				break;
 			case 14:
-				status_file = Safe_strdup(optarg);
-				pInputOpts->pszPassThroughParms = addPassThroughLongParm("status", status_file, pInputOpts->pszPassThroughParms);
+				status_file_dir = Safe_strdup(optarg);
+				pInputOpts->pszPassThroughParms = addPassThroughLongParm("status", status_file_dir, pInputOpts->pszPassThroughParms);
 				break;
 			case 15:
 				netbackup_service_host = Safe_strdup(optarg);
@@ -755,7 +759,9 @@ fillInputOptions(int argc, char **argv, InputOptions * pInputOpts)
 				if (change_schema!= NULL)
 					free(change_schema);
 				break;
-
+			case 18:
+				forceErrorScan = true;
+				break;
 			default:
 				mpp_err_msg_cache(logError, progname, "Try \"%s --help\" for more information.\n", progname);
 				return false;
@@ -984,6 +990,7 @@ threadProc(void *arg)
 	char	   *pszPassThroughCredentials;
 	char	   *pszPassThroughTargetInfo;
 	PQExpBuffer Qry;
+	PQExpBuffer pqBuffer;
 	PGresult   *pRes;
 	int			sock;
 	bool		bSentCancelMessage;
@@ -1020,7 +1027,7 @@ threadProc(void *arg)
 		sSegDB->pszDBName = Safe_strdup(pInputOpts->pszDBName);
 	}
 
-	/* connect to the source segDB to start gp_dump_agent there */
+	/* connect to the source segDB to start gp_restore_agent there */
 	pConn = MakeDBConnection(sSegDB, false);
 	if (PQstatus(pConn) == CONNECTION_BAD)
 	{
@@ -1178,8 +1185,10 @@ threadProc(void *arg)
 					g_b_SendCancelMessage = true;
 					bIsFinished = true;
 					pParm->bSuccess = false;
+					pqBuffer = createPQExpBuffer();
 					/* Make call to get error message from file on server */
-					pParm->pszErrorMsg = ReadBackendBackupFile(pConn, pInputOpts->pszBackupDirectory, pszKey, BFT_RESTORE_STATUS, progname);
+					ReadBackendBackupFileError(pConn, status_file_dir, pszKey, BFT_RESTORE_STATUS, progname, pqBuffer);
+					pParm->pszErrorMsg = pqBuffer->data;
 
 					mpp_err_msg(logError, progname, "restore failed for source dbid %d, target dbid %d on host %s\n",
 								sSegDB->dbid, tSegDB->dbid, StringNotNull(sSegDB->pszHost, "localhost"));
@@ -1205,6 +1214,23 @@ threadProc(void *arg)
 					bSentCancelMessage = true;
 				}
 			}
+		}
+	}
+
+	/*
+	 * We want a force scan of the restore status file for ERRORS, even if
+	 * segment returns success, because psql client does not report the correct
+	 * error code upon SQL failure.
+	 */
+	if(forceErrorScan && pParm->bSuccess)
+	{
+		pqBuffer = createPQExpBuffer();
+		int status = ReadBackendBackupFileError(pConn, status_file_dir, pszKey, BFT_RESTORE_STATUS, progname, pqBuffer);
+		if (status != 0)
+		{
+			pParm->pszErrorMsg = pqBuffer->data;
+			pParm->bSuccess = false;
+			g_b_SendCancelMessage = true;
 		}
 	}
 
@@ -1299,7 +1325,7 @@ restoreMaster(InputOptions * pInputOpts,
 	pParm->pTargetSegDBData = tSegDB;
 	pParm->pSourceSegDBData = sSegDB;
 	pParm->pOptionsData = pInputOpts;
-	pParm->bSuccess = false;
+	pParm->bSuccess = true;
 	pParm->pszErrorMsg = NULL;
 	pParm->pszRemoteBackupPath = NULL;
 
@@ -1477,7 +1503,7 @@ spinOffThreads(PGconn *pConn, InputOptions * pInputOpts, const RestorePairArray 
 		pParm->pSourceSegDBData = &restorePairAr->pData[i].segdb_source;
 		pParm->pTargetSegDBData = &restorePairAr->pData[i].segdb_target;
 		pParm->pOptionsData = pInputOpts;
-		pParm->bSuccess = false;
+		pParm->bSuccess = true;
 
 		/* exclude master node */
 		if (pParm->pTargetSegDBData->role == ROLE_MASTER)


### PR DESCRIPTION
By default, gpdbrestore and gpcrondump ignore errors like
SQL execution and broken pipes, but log them into the status file,
adding an option to force a scan of status file in the end.

Authors: Pengcheng Tang, Nikhil Kak
